### PR TITLE
Swift 2.0 compatability

### DIFF
--- a/Haneke.xcodeproj/project.pbxproj
+++ b/Haneke.xcodeproj/project.pbxproj
@@ -415,6 +415,7 @@
 		A095C94D1980418C00CD0F4C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0600;
 				ORGANIZATIONNAME = Haneke;
 				TargetAttributes = {

--- a/Haneke/Cache.swift
+++ b/Haneke/Cache.swift
@@ -37,7 +37,7 @@ public class Cache<T : DataConvertible where T.Result == T, T : DataRepresentabl
     
     let name : String
     
-    var memoryWarningObserver : NSObjectProtocol!
+    var memoryWarningObserver : NSObjectProtocol? = nil
     
     public init(name : String) {
         self.name = name
@@ -52,16 +52,18 @@ public class Cache<T : DataConvertible where T.Result == T, T : DataRepresentabl
             }
         )
         
-        var originalFormat = Format<T>(name: HanekeGlobals.Cache.OriginalFormatName)
+        let originalFormat = Format<T>(name: HanekeGlobals.Cache.OriginalFormatName)
         self.addFormat(originalFormat)
     }
     
     deinit {
-        let notifications = NSNotificationCenter.defaultCenter()
-        notifications.removeObserver(memoryWarningObserver, name: UIApplicationDidReceiveMemoryWarningNotification, object: nil)
+        if let memoryWarningObserver = memoryWarningObserver {
+            let notifications = NSNotificationCenter.defaultCenter()
+            notifications.removeObserver(memoryWarningObserver, name: UIApplicationDidReceiveMemoryWarningNotification, object: nil)
+        }
     }
     
-    public func set(#value : T, key: String, formatName : String = HanekeGlobals.Cache.OriginalFormatName, success succeed : ((T) -> ())? = nil) {
+    public func set(value value : T, key: String, formatName : String = HanekeGlobals.Cache.OriginalFormatName, success succeed : ((T) -> ())? = nil) {
         if let (format, memoryCache, diskCache) = self.formats[formatName] {
             self.format(value: value, format: format) { formattedValue in
                 let wrapper = ObjectWrapper(value: formattedValue)
@@ -75,13 +77,14 @@ public class Cache<T : DataConvertible where T.Result == T, T : DataRepresentabl
         }
     }
     
-    public func fetch(#key : String, formatName : String = HanekeGlobals.Cache.OriginalFormatName, failure fail : Fetch<T>.Failer? = nil, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
+    public func fetch(key key : String, formatName : String = HanekeGlobals.Cache.OriginalFormatName, failure fail : Fetch<T>.Failer? = nil, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
         let fetch = Cache.buildFetch(failure: fail, success: succeed)
         if let (format, memoryCache, diskCache) = self.formats[formatName] {
-            if let wrapper = memoryCache.objectForKey(key) as? ObjectWrapper, let result = wrapper.value as? T {
-                fetch.succeed(result)
-                diskCache.updateAccessDate(self.dataFromValue(result, format: format), key: key)
-                return fetch
+            if let wrapper = memoryCache.objectForKey(key) as? ObjectWrapper,
+                let result = wrapper.value as? T {
+                    fetch.succeed(result)
+                    diskCache.updateAccessDate(self.dataFromValue(result, format: format), key: key)
+                    return fetch
             }
 
             self.fetchFromDiskCache(diskCache, key: key, memoryCache: memoryCache, failure: { error in
@@ -99,7 +102,7 @@ public class Cache<T : DataConvertible where T.Result == T, T : DataRepresentabl
         return fetch
     }
     
-    public func fetch(#fetcher : Fetcher<T>, formatName : String = HanekeGlobals.Cache.OriginalFormatName, failure fail : Fetch<T>.Failer? = nil, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
+    public func fetch(fetcher fetcher : Fetcher<T>, formatName : String = HanekeGlobals.Cache.OriginalFormatName, failure fail : Fetch<T>.Failer? = nil, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
         let key = fetcher.key
         let fetch = Cache.buildFetch(failure: fail, success: succeed)
         self.fetch(key: key, formatName: formatName, failure: { error in
@@ -122,7 +125,7 @@ public class Cache<T : DataConvertible where T.Result == T, T : DataRepresentabl
         return fetch
     }
 
-    public func remove(#key : String, formatName : String = HanekeGlobals.Cache.OriginalFormatName) {
+    public func remove(key key : String, formatName : String = HanekeGlobals.Cache.OriginalFormatName) {
         if let (_, memoryCache, diskCache) = self.formats[formatName] {
             memoryCache.removeObjectForKey(key)
             diskCache.removeData(key)
@@ -164,10 +167,17 @@ public class Cache<T : DataConvertible where T.Result == T, T : DataRepresentabl
         return cachePath
     }()
     
-    func formatPath(#formatName : String) -> String {
+    func formatPath(formatName formatName : String) -> String {
         let formatPath = self.cachePath.stringByAppendingPathComponent(formatName)
         var error : NSError? = nil
-        let success = NSFileManager.defaultManager().createDirectoryAtPath(formatPath, withIntermediateDirectories: true, attributes: nil, error: &error)
+        let success: Bool
+        do {
+            try NSFileManager.defaultManager().createDirectoryAtPath(formatPath, withIntermediateDirectories: true, attributes: nil)
+            success = true
+        } catch let error1 as NSError {
+            error = error1
+            success = false
+        }
         if (!success) {
             Log.error("Failed to create directory \(formatPath)", error)
         }
@@ -197,7 +207,7 @@ public class Cache<T : DataConvertible where T.Result == T, T : DataRepresentabl
             }
         }) { data in
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), {
-                var value = T.convertFromData(data)
+                let value = T.convertFromData(data)
                 if let value = value {
                     let descompressedValue = self.decompressedImageIfNeeded(value)
                     dispatch_async(dispatch_get_main_queue(), {
@@ -218,7 +228,7 @@ public class Cache<T : DataConvertible where T.Result == T, T : DataRepresentabl
         }
     }
     
-    private func format(#value : T, format : Format<T>, success succeed : (T) -> ()) {
+    private func format(value value : T, format : Format<T>, success succeed : (T) -> ()) {
         // HACK: Ideally Cache shouldn't treat images differently but I can't think of any other way of doing this that doesn't complicate the API for other types.
         if format.isIdentity && !(value is UIImage) {
             succeed(value)
@@ -262,17 +272,17 @@ public class Cache<T : DataConvertible where T.Result == T, T : DataRepresentabl
     // MARK: Convenience fetch
     // Ideally we would put each of these in the respective fetcher file as a Cache extension. Unfortunately, this fails to link when using the framework in a project as of Xcode 6.1.
     
-    public func fetch(#key : String, @autoclosure(escaping) value getValue : () -> T.Result, formatName : String = HanekeGlobals.Cache.OriginalFormatName, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
+    public func fetch(key key : String, @autoclosure(escaping) value getValue : () -> T.Result, formatName : String = HanekeGlobals.Cache.OriginalFormatName, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
         let fetcher = SimpleFetcher<T>(key: key, value: getValue)
         return self.fetch(fetcher: fetcher, formatName: formatName, success: succeed)
     }
     
-    public func fetch(#path : String, formatName : String = HanekeGlobals.Cache.OriginalFormatName,  failure fail : Fetch<T>.Failer? = nil, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
+    public func fetch(path path : String, formatName : String = HanekeGlobals.Cache.OriginalFormatName,  failure fail : Fetch<T>.Failer? = nil, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
         let fetcher = DiskFetcher<T>(path: path)
         return self.fetch(fetcher: fetcher, formatName: formatName, failure: fail, success: succeed)
     }
     
-    public func fetch(#URL : NSURL, formatName : String = HanekeGlobals.Cache.OriginalFormatName,  failure fail : Fetch<T>.Failer? = nil, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
+    public func fetch(URL URL : NSURL, formatName : String = HanekeGlobals.Cache.OriginalFormatName,  failure fail : Fetch<T>.Failer? = nil, success succeed : Fetch<T>.Succeeder? = nil) -> Fetch<T> {
         let fetcher = NetworkFetcher<T>(URL: URL)
         return self.fetch(fetcher: fetcher, formatName: formatName, failure: fail, success: succeed)
     }

--- a/Haneke/CryptoSwiftMD5.swift
+++ b/Haneke/CryptoSwiftMD5.swift
@@ -28,10 +28,10 @@ func arrayOfBytes<T>(value:T, length:Int? = nil) -> [UInt8] {
     let totalBytes = length ?? (sizeofValue(value) * 8)
     var v = value
     
-    var valuePointer = UnsafeMutablePointer<T>.alloc(1)
+    let valuePointer = UnsafeMutablePointer<T>.alloc(1)
     valuePointer.memory = value
     
-    var bytesPointer = UnsafeMutablePointer<UInt8>(valuePointer)
+    let bytesPointer = UnsafeMutablePointer<UInt8>(valuePointer)
     var bytes = [UInt8](count: totalBytes, repeatedValue: 0)
     for j in 0..<min(sizeof(T),totalBytes) {
         bytes[totalBytes - 1 - j] = (bytesPointer + j).memory
@@ -70,7 +70,7 @@ class HashBase {
     
     /** Common part for hash calculation. Prepare header data. */
     func prepare(_ len:Int = 64) -> NSMutableData {
-        var tmpMessage: NSMutableData = NSMutableData(data: self.message)
+        let tmpMessage: NSMutableData = NSMutableData(data: self.message)
         
         // Step 1. Append Padding Bits
         tmpMessage.appendBytes([0x80]) // append one bit (UInt8 with one bit) to message
@@ -82,7 +82,7 @@ class HashBase {
             counter++
             msgLength++
         }
-        var bufZeros = UnsafeMutablePointer<UInt8>(calloc(counter, sizeof(UInt8)))
+        let bufZeros = UnsafeMutablePointer<UInt8>(calloc(counter, sizeof(UInt8)))
         tmpMessage.appendBytes(bufZeros, length: counter)
         
         return tmpMessage
@@ -130,7 +130,7 @@ class MD5 : HashBase {
         // Step 2. Append Length a 64-bit representation of lengthInBits
         var lengthInBits = (message.length * 8)
         var lengthBytes = lengthInBits.bytes(64 / 8)
-        tmpMessage.appendBytes(reverse(lengthBytes))
+        tmpMessage.appendBytes(Array(lengthBytes.reverse()));
         
         // Process the message in successive 512-bit chunks:
         let chunkSizeBytes = 512 / 8 // 64
@@ -180,7 +180,7 @@ class MD5 : HashBase {
                 dTemp = D
                 D = C
                 C = B
-                B = B &+ rotateLeft((A &+ F &+ k[j] &+ M[g]), s[j])
+                B = B &+ rotateLeft((A &+ F &+ k[j] &+ M[g]), n: s[j])
                 A = dTemp
             }
             

--- a/Haneke/Data.swift
+++ b/Haneke/Data.swift
@@ -40,7 +40,7 @@ extension String : DataConvertible, DataRepresentable {
     public typealias Result = String
     
     public static func convertFromData(data:NSData) -> Result? {
-        var string = NSString(data: data, encoding: NSUTF8StringEncoding)
+        let string = NSString(data: data, encoding: NSUTF8StringEncoding)
         return string as? Result
     }
     
@@ -72,7 +72,8 @@ public enum JSON : DataConvertible, DataRepresentable {
     
     public static func convertFromData(data:NSData) -> Result? {
         var error : NSError?
-        if let object : AnyObject = NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions.allZeros, error: &error) {
+        do {
+            let object : AnyObject = try NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions())
             switch (object) {
             case let dictionary as [String:AnyObject]:
                 return JSON.Dictionary(dictionary)
@@ -81,7 +82,8 @@ public enum JSON : DataConvertible, DataRepresentable {
             default:
                 return nil
             }
-        } else {
+        } catch var error1 as NSError {
+            error = error1
             Log.error("Invalid JSON data", error)
             return nil
         }
@@ -90,9 +92,17 @@ public enum JSON : DataConvertible, DataRepresentable {
     public func asData() -> NSData! {
         switch (self) {
         case .Dictionary(let dictionary):
-            return NSJSONSerialization.dataWithJSONObject(dictionary, options: NSJSONWritingOptions.allZeros, error: nil)
+            do {
+                return try NSJSONSerialization.dataWithJSONObject(dictionary, options: NSJSONWritingOptions())
+            } catch _ {
+                return nil
+            }
         case .Array(let array):
-            return NSJSONSerialization.dataWithJSONObject(array, options: NSJSONWritingOptions.allZeros, error: nil)
+            do {
+                return try NSJSONSerialization.dataWithJSONObject(array, options: NSJSONWritingOptions())
+            } catch _ {
+                return nil
+            }
         }
     }
     

--- a/Haneke/DiskFetcher.swift
+++ b/Haneke/DiskFetcher.swift
@@ -55,7 +55,13 @@ public class DiskFetcher<T : DataConvertible> : Fetcher<T> {
         }
         
         var error: NSError?
-        let data = NSData(contentsOfFile: self.path, options: NSDataReadingOptions.allZeros, error: &error)
+        let data: NSData?
+        do {
+            data = try NSData(contentsOfFile: self.path, options: NSDataReadingOptions())
+        } catch let error1 as NSError {
+            error = error1
+            data = nil
+        }
         if data == nil {
             dispatch_async(dispatch_get_main_queue()) {
                 fail(error)

--- a/Haneke/Haneke.swift
+++ b/Haneke/Haneke.swift
@@ -49,7 +49,7 @@ public struct Shared {
     }
 }
 
-func errorWithCode(code : Int, #description : String) -> NSError {
+func errorWithCode(code : Int, description : String) -> NSError {
     let userInfo = [NSLocalizedDescriptionKey: description]
     return NSError(domain: HanekeGlobals.Domain, code: code, userInfo: userInfo)
 }

--- a/Haneke/NSFileManager+Haneke.swift
+++ b/Haneke/NSFileManager+Haneke.swift
@@ -12,46 +12,61 @@ extension NSFileManager {
 
     func enumerateContentsOfDirectoryAtPath(path : String, orderedByProperty property : String, ascending : Bool, usingBlock block : (NSURL, Int, inout Bool) -> Void ) {
 
-        let directoryURL = NSURL(fileURLWithPath: path)
-        if directoryURL == nil { return }
-        var error : NSError?
-        if let contents = self.contentsOfDirectoryAtURL(directoryURL!, includingPropertiesForKeys: [property], options: NSDirectoryEnumerationOptions.allZeros, error: &error) as? [NSURL] {
-
-            let sortedContents = contents.sorted({(URL1 : NSURL, URL2 : NSURL) -> Bool in
-
-                // Maybe there's a better way to do this. See: http://stackoverflow.com/questions/25502914/comparing-anyobject-in-swift
-
-                var value1 : AnyObject?
-                if !URL1.getResourceValue(&value1, forKey: property, error: nil) { return true }
-                var value2 : AnyObject?
-                if !URL2.getResourceValue(&value2, forKey: property, error: nil) { return false }
-
-
-                if let string1 = value1 as? String, let string2 = value2 as? String {
-                    return ascending ? string1 < string2 : string2 < string1
-                }
+        let directoryURL : NSURL? = NSURL(fileURLWithPath: path)
+        if let directoryURL = directoryURL
+        {
+            do {
                 
-                if let date1 = value1 as? NSDate, let date2 = value2 as? NSDate {
-                    return ascending ? date1 < date2 : date2 < date1
+                if let contents = try self.contentsOfDirectoryAtURL(directoryURL, includingPropertiesForKeys: [property], options: NSDirectoryEnumerationOptions()) as? [NSURL] {
+
+                    let sortedContents = contents.sort({(URL1 : NSURL, URL2 : NSURL) -> Bool in
+
+                        // Maybe there's a better way to do this. See: http://stackoverflow.com/questions/25502914/comparing-anyobject-in-swift
+
+                        var value1 : AnyObject?
+                        do {
+                            try URL1.getResourceValue(&value1, forKey: property)
+                        } catch _ { return true }
+                        var value2 : AnyObject?
+                        do {
+                            try URL2.getResourceValue(&value2, forKey: property)
+                        } catch _ { return false }
+
+
+                        if  let string1 = value1 as? String,
+                            let string2 = value2 as? String {
+                            return ascending ? string1 < string2 : string2 < string1
+                        }
+                        
+                        if  let date1 = value1 as? NSDate,
+                            let date2 = value2 as? NSDate {
+                            return ascending ? date1 < date2 : date2 < date1
+                        }
+
+                        if  let number1 = value1 as? NSNumber,
+                            let number2 = value2 as? NSNumber {
+                            return ascending ? number1 < number2 : number2 < number1
+                        }
+
+                        return false
+                    })
+
+                    for (i, v) in sortedContents.enumerate() {
+                        var stop : Bool = false
+                        block(v, i, &stop)
+                        if stop { break }
+                    }
                 }
-
-                if let number1 = value1 as? NSNumber, let number2 = value2 as? NSNumber {
-                    return ascending ? number1 < number2 : number2 < number1
-                }
-
-                return false
-            })
-
-            for (i, v) in enumerate(sortedContents) {
-                var stop : Bool = false
-                block(v, i, &stop)
-                if stop { break }
             }
-        } else {
-            Log.error("Failed to list directory", error)
+            catch let error as NSError {
+                print(error.localizedDescription)
+            }
+            catch
+            {
+                
+            }
         }
     }
-
 }
 
 func < (lhs: NSDate, rhs: NSDate) -> Bool {

--- a/Haneke/NetworkFetcher.swift
+++ b/Haneke/NetworkFetcher.swift
@@ -30,7 +30,7 @@ public class NetworkFetcher<T : DataConvertible> : Fetcher<T> {
     public init(URL : NSURL) {
         self.URL = URL
 
-        let key =  URL.absoluteString!
+        let key =  URL.absoluteString
         super.init(key: key)
     }
     
@@ -44,7 +44,8 @@ public class NetworkFetcher<T : DataConvertible> : Fetcher<T> {
     
     public override func fetch(failure fail : ((NSError?) -> ()), success succeed : (T.Result) -> ()) {
         self.cancelled = false
-        self.task = self.session.dataTaskWithURL(self.URL) {[weak self] (data : NSData!, response : NSURLResponse!, error : NSError!) -> Void in
+        
+        self.task = self.session.dataTaskWithURL(self.URL) {[weak self] (data, response, error) -> Void in
             if let strongSelf = self {
                 strongSelf.onReceiveData(data, response: response, error: error, failure: fail, success: succeed)
             }
@@ -68,7 +69,7 @@ public class NetworkFetcher<T : DataConvertible> : Fetcher<T> {
         if let error = error {
             if (error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled) { return }
             
-            Log.debug("Request \(URL.absoluteString!) failed", error)
+            Log.debug("Request \(URL.absoluteString) failed", error)
             dispatch_async(dispatch_get_main_queue(), { fail(error) })
             return
         }
@@ -76,7 +77,7 @@ public class NetworkFetcher<T : DataConvertible> : Fetcher<T> {
         // Intentionally avoiding `if let` to continue in golden path style.
         let httpResponse : NSHTTPURLResponse! = response as? NSHTTPURLResponse
         if httpResponse == nil {
-            Log.debug("Request \(URL.absoluteString!) received unknown response \(response)")
+            Log.debug("Request \(URL.absoluteString) received unknown response \(response)")
             return
         }
         
@@ -96,7 +97,7 @@ public class NetworkFetcher<T : DataConvertible> : Fetcher<T> {
         let value : T.Result? = T.convertFromData(data)
         if value == nil {
             let localizedFormat = NSLocalizedString("Failed to convert value from data at URL %@", comment: "Error description")
-            let description = String(format:localizedFormat, URL.absoluteString!)
+            let description = String(format:localizedFormat, URL.absoluteString)
             self.failWithCode(.InvalidData, localizedDescription: description, failure: fail)
             return
         }

--- a/Haneke/String+Haneke.swift
+++ b/Haneke/String+Haneke.swift
@@ -38,7 +38,7 @@ extension String {
     func MD5Filename() -> String {
         let MD5String = self.MD5String()
         let pathExtension = self.pathExtension
-        if count(pathExtension) > 0 {
+        if pathExtension.characters.count > 0 {
             return MD5String.stringByAppendingPathExtension(pathExtension) ?? MD5String
         } else {
             return MD5String

--- a/Haneke/UIButton+Haneke.swift
+++ b/Haneke/UIButton+Haneke.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import ObjectiveC
 
 public extension UIButton {
     
@@ -70,7 +71,8 @@ public extension UIButton {
             if let fetcher = fetcher {
                 wrapper = ObjectWrapper(value: fetcher)
             }
-            objc_setAssociatedObject(self, &HanekeGlobals.UIKit.SetImageFetcherKey, wrapper, UInt(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
+            let policy : objc_AssociationPolicy = objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC
+            objc_setAssociatedObject(self, &HanekeGlobals.UIKit.SetImageFetcherKey, wrapper, policy)
         }
     }
     
@@ -180,7 +182,8 @@ public extension UIButton {
             if let fetcher = fetcher {
                 wrapper = ObjectWrapper(value: fetcher)
             }
-            objc_setAssociatedObject(self, &HanekeGlobals.UIKit.SetBackgroundImageFetcherKey, wrapper, UInt(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
+            let policy : objc_AssociationPolicy = objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC
+            objc_setAssociatedObject(self, &HanekeGlobals.UIKit.SetBackgroundImageFetcherKey, wrapper, policy)
         }
     }
     

--- a/Haneke/UIImage+Haneke.swift
+++ b/Haneke/UIImage+Haneke.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import CoreGraphics
 
 extension UIImage {
 
@@ -38,13 +39,16 @@ extension UIImage {
         let originalImageRef = self.CGImage
         let originalBitmapInfo = CGImageGetBitmapInfo(originalImageRef)
         let alphaInfo = CGImageGetAlphaInfo(originalImageRef)
+        let noneskipFirst = CGBitmapInfo(rawValue: CGImageAlphaInfo.NoneSkipFirst.rawValue)
         
         // See: http://stackoverflow.com/questions/23723564/which-cgimagealphainfo-should-we-use
         var bitmapInfo = originalBitmapInfo
         switch (alphaInfo) {
         case .None:
-            bitmapInfo &= ~CGBitmapInfo.AlphaInfoMask
-            bitmapInfo |= CGBitmapInfo(CGImageAlphaInfo.NoneSkipFirst.rawValue)
+//            bitmapInfo &= ~CGBitmapInfo.AlphaInfoMask
+            bitmapInfo.subtract(CGBitmapInfo.AlphaInfoMask)
+//            bitmapInfo |= CGBitmapInfo(CGImageAlphaInfo.NoneSkipFirst.rawValue)
+            bitmapInfo.unionInPlace(noneskipFirst)
         case .PremultipliedFirst, .PremultipliedLast, .NoneSkipFirst, .NoneSkipLast:
             break
         case .Only, .Last, .First: // Unsupported
@@ -53,8 +57,9 @@ extension UIImage {
         
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         let pixelSize = CGSizeMake(self.size.width * self.scale, self.size.height * self.scale)
-        if let context = CGBitmapContextCreate(nil, Int(ceil(pixelSize.width)), Int(ceil(pixelSize.height)), CGImageGetBitsPerComponent(originalImageRef), 0, colorSpace, bitmapInfo) {
-            
+        
+        if let context = CGBitmapContextCreate(nil, Int(pixelSize.width), Int(pixelSize.height), CGImageGetBitsPerComponent(originalImageRef), 0, colorSpace, bitmapInfo.rawValue)
+        {
             let imageRect = CGRectMake(0, 0, pixelSize.width, pixelSize.height)
             UIGraphicsPushContext(context)
             

--- a/Haneke/UIImageView+Haneke.swift
+++ b/Haneke/UIImageView+Haneke.swift
@@ -72,7 +72,8 @@ public extension UIImageView {
             if let fetcher = fetcher {
                 wrapper = ObjectWrapper(value: fetcher)
             }
-            objc_setAssociatedObject(self, &HanekeGlobals.UIKit.SetImageFetcherKey, wrapper, UInt(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
+            let policy : objc_AssociationPolicy = objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC
+            objc_setAssociatedObject(self, &HanekeGlobals.UIKit.SetImageFetcherKey, wrapper, policy)
         }
     }
     

--- a/Haneke/UIView+Haneke.swift
+++ b/Haneke/UIView+Haneke.swift
@@ -28,7 +28,7 @@ public extension HanekeGlobals {
                     return resizer.resizeImage($0)
             }
             format.convertToData = {(image : UIImage) -> NSData in
-                image.hnk_data(compressionQuality: HanekeGlobals.UIKit.DefaultFormat.CompressionQuality)
+                image.hnk_data(HanekeGlobals.UIKit.DefaultFormat.CompressionQuality)
             }
             return format
         }


### PR DESCRIPTION
This merge gets rid of even more Swift 2.0 incompatibilities and should compile almost completely clean in Xcode 7.

A few warnings are left over, including:

```
Fetch.swift:61:15: warning: extraneous '_' in parameter: 'error' has no keyword argument name
    func fail(_ error : NSError? = nil) {
```
